### PR TITLE
added more test for tomlParser

### DIFF
--- a/tests/unit/helpers/tomlParser.test.ts
+++ b/tests/unit/helpers/tomlParser.test.ts
@@ -50,4 +50,29 @@ describe('tomlParser', () => {
     expect(fs.readFileSync).not.toHaveBeenCalled();
     expect(parse).not.toHaveBeenCalled();
   });
+
+  test('logs an error and exits the process if an error occurs', () => {
+    const mockError = new Error('Mocked parser error');
+    (fs.existsSync as jest.Mock).mockReturnValue(true);
+    (fs.readFileSync as jest.Mock).mockImplementation(() => {
+      throw mockError;
+    });
+
+    const consoleErrorSpy = jest
+      .spyOn(console, 'error')
+      .mockImplementation(() => {});
+    const processExitSpy = jest
+      .spyOn(process, 'exit')
+      .mockImplementation(() => {
+        throw new Error('exit called');
+      });
+
+    expect(() => tomlParser()).toThrow('exit called');
+
+    expect(consoleErrorSpy).toHaveBeenCalledWith(`${mockError}`);
+    expect(processExitSpy).toHaveBeenCalledWith(1);
+
+    consoleErrorSpy.mockRestore();
+    processExitSpy.mockRestore();
+  });
 });


### PR DESCRIPTION
# Description

This PR contains an additional test for tomlParser helper function.
Previously, the tomlParser.test.ts did not cover these lines:

```typescript
catch (err) {
  console.error(`${err}`);
  process.exit(1);
}
```

The added test now covers this line, making toml_parser/index.ts 100% in coverage.

# Checklist

- [x] Build does not fail.
- [x] Tested locally.
- [x] Linting errors if any are resolved.

# Testing Instructions

## Run the tester

```bash
npm test
```
